### PR TITLE
Fix SonicBOOM Linux Boot

### DIFF
--- a/arch/riscv/mm/init.c
+++ b/arch/riscv/mm/init.c
@@ -206,6 +206,7 @@ void __set_fixmap(enum fixed_addresses idx, phys_addr_t phys, pgprot_t prot)
 		pte_clear(&init_mm, addr, ptep);
 		local_flush_tlb_page(addr);
 	}
+	local_flush_tlb_all();
 }
 
 static pte_t *__init get_pte_virt(phys_addr_t pa)


### PR DESCRIPTION
This propagates an old fix to the main Linux branch. This commit is basically needed for most, if not all SonicBoom work.