### PR TITLE
Enable RoCC instructions after context switches

### DIFF
--- a/arch/riscv/include/asm/switch_to.h
+++ b/arch/riscv/include/asm/switch_to.h
@@ -42,6 +42,9 @@ static inline void fstate_restore(struct task_struct *task,
 		__fstate_restore(task);
 		__fstate_clean(regs);
 	}
+#ifdef CONFIG_RISCV_ROCC
+	regs->status |= SR_XS_INITIAL;
+#endif
 }
 
 static inline void __switch_to_aux(struct task_struct *prev,

--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -68,9 +68,6 @@ void start_thread(struct pt_regs *regs, unsigned long pc,
 	unsigned long sp)
 {
 	regs->status = SR_PIE;
-#ifdef CONFIG_RISCV_ROCC
-	regs->status |= SR_XS_INITIAL;
-#endif
 	if (has_fpu) {
 		regs->status |= SR_FS_INITIAL;
 		/*
@@ -79,6 +76,9 @@ void start_thread(struct pt_regs *regs, unsigned long pc,
 		 */
 		fstate_restore(current, regs);
 	}
+#ifdef CONFIG_RISCV_ROCC
+	regs->status |= SR_XS_INITIAL;
+#endif
 	regs->epc = pc;
 	regs->sp = sp;
 	set_fs(USER_DS);


### PR DESCRIPTION
When using pthreads with cores having RoCC instructions, context switches clear the XS bit causing illegal instruction program failures. This fix forces the XS bit to be set whenever a context switch is done to avoid this issue.