### PR TITLE
Initialize random number generator in early boot

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -558,6 +558,21 @@ config RISCV_TIMEBASE_DIV
 	  integer factor slower than reported by the platform.
 	  This makes simulated systems more responsive to user interaction.
 
+config OVERRIDE_RNG_ENTROPY
+        bool "Override rng init entropy with OVERRIDE_RNG_ENTROPY_VALUE"
+        default n
+        help
+          Override the random number generator init entropy during early boot
+          See drivers/char/random.c:random_init_early()
+          This prevents apps from blocking on the rng.
+
+config OVERRIDE_RNG_ENTROPY_VALUE
+        int "Value for rng init entropy"
+        default 256
+        depends on OVERRIDE_RNG_ENTROPY
+        help
+          Default: 256, the minimum required threshold per drivers/char/random.c to initialize the rng
+
 endmenu # "Kernel features"
 
 menu "Boot options"

--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -877,8 +877,8 @@ void __init random_init_early(const char *command_line)
 		
 		/*
 		 * With random.trust_cpu=on in the kernel command line, 
-   		 * sets entropy to 256 to initialize random number geenrator
-      		 * in early boot.
+   		 * sets entropy to 256 (minimum threshold from line 612) 
+      		 * to initialize random number geenrator in early boot.
 		 */
 		size_t artifical_arch_bits = 256;
 		_credit_init_bits(artificial_arch_bits);

--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -871,8 +871,18 @@ void __init random_init_early(const char *command_line)
 	/* Reseed if already seeded by earlier phases. */
 	if (crng_ready())
 		crng_reseed(NULL);
-	else if (trust_cpu)
-		_credit_init_bits(arch_bits);
+	else if (trust_cpu) {
+
+		// _credit_init_bits(arch_bits);
+		
+		/*
+		 * With random.trust_cpu=on in the kernel command line, 
+   		 * sets entropy to 256 to initialize random number geenrator
+      		 * in early boot.
+		 */
+		size_t artifical_arch_bits = 256;
+		_credit_init_bits(artificial_arch_bits);
+	}	
 }
 
 /*

--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -840,6 +840,10 @@ static struct notifier_block pm_notifier = { .notifier_call = random_pm_notifica
  */
 void __init random_init_early(const char *command_line)
 {
+#ifdef CONFIG_OVERRIDE_RNG_ENTROPY
+        _credit_init_bits(CONFIG_OVERRIDE_RNG_ENTROPY_VALUE);
+        pr_notice("overriding entropy value\n");
+#else
 	unsigned long entropy[BLAKE2S_BLOCK_SIZE / sizeof(long)];
 	size_t i, longs, arch_bits;
 
@@ -871,18 +875,9 @@ void __init random_init_early(const char *command_line)
 	/* Reseed if already seeded by earlier phases. */
 	if (crng_ready())
 		crng_reseed(NULL);
-	else if (trust_cpu) {
-
-		// _credit_init_bits(arch_bits);
-		
-		/*
-		 * With random.trust_cpu=on in the kernel command line, 
-   		 * sets entropy to 256 (minimum threshold from line 612) 
-      		 * to initialize random number geenrator in early boot.
-		 */
-		size_t artifical_arch_bits = 256;
-		_credit_init_bits(artificial_arch_bits);
-	}	
+	else if (trust_cpu)
+		_credit_init_bits(arch_bits);
+#endif
 }
 
 /*


### PR DESCRIPTION
The random number generator (most commonly `/dev/urandom`) is not initialized (and thus blocks on calls) until it hits a minimum entropy threshold, currently 256 (bits of entropy). 

This manifests as applications hanging unexplicably and then running as expected after a long time period. Hitting the minimum entropy threshold in a deterministic simulated environment requires lots of cycles and IO ops. We bypass the issue by manually overriding the entropy value during early boot. 

The override uses two Kconfig options:
- OVERRIDE_RNG_ENTROPY to enable the override
- OVERRIDE_RNG_ENTROPY_VALUE for the override value
   * Depends on OVERRIDE_RNG_ENTROPY