### PR TITLE
Jump label patch log

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -1367,6 +1367,12 @@ config BUILTIN_DTB_NAME
 	  DTS file path (without suffix, relative to arch/riscv/boot/dts)
 	  for the DTS file that will be used to produce the DTB linked into the
 	  kernel.
+	
+config JUMP_LABEL_PATCH_LOG_SNAPSHOT
+	bool "Snapshot jump labels"
+	depends on JUMP_LABEL
+	help
+	  Snapshot jump labels for debugging purposes.
 
 endmenu # "Boot options"
 

--- a/arch/riscv/include/asm/elf.h
+++ b/arch/riscv/include/asm/elf.h
@@ -15,6 +15,7 @@
 #include <asm/byteorder.h>
 #include <asm/cacheinfo.h>
 #include <asm/cpufeature.h>
+#include <asm/vdso.h>
 
 /*
  * These are used to set parameters in the core dumps.
@@ -90,8 +91,9 @@ do {								\
 	 * warning of cast from pointer to integer for		\
 	 * COMPAT ELFCLASS32.					\
 	 */							\
-	NEW_AUX_ENT(AT_SYSINFO_EHDR,				\
-		(elf_addr_t)(ulong)current->mm->context.vdso);	\
+	if (vdso_enabled)					\
+		NEW_AUX_ENT(AT_SYSINFO_EHDR,			\
+			(elf_addr_t)(ulong)current->mm->context.vdso); \
 	NEW_AUX_ENT(AT_L1I_CACHESIZE,				\
 		get_cache_size(1, CACHE_TYPE_INST));		\
 	NEW_AUX_ENT(AT_L1I_CACHEGEOMETRY,			\

--- a/arch/riscv/include/asm/vdso.h
+++ b/arch/riscv/include/asm/vdso.h
@@ -33,6 +33,7 @@ extern char compat_vdso_start[], compat_vdso_end[];
 #endif /* CONFIG_COMPAT */
 
 extern char vdso_start[], vdso_end[];
+extern unsigned int vdso_enabled;
 
 #endif /* !__ASSEMBLY__ */
 

--- a/arch/riscv/kernel/cpufeature.c
+++ b/arch/riscv/kernel/cpufeature.c
@@ -15,6 +15,7 @@
 #include <linux/memory.h>
 #include <linux/module.h>
 #include <linux/of.h>
+#include <linux/jump_label_patch_log.h>
 #include <asm/acpi.h>
 #include <asm/alternative.h>
 #include <asm/bugs.h>
@@ -1220,6 +1221,15 @@ void __init_or_module riscv_cpufeature_patch_func(struct alt_entry *begin,
 
 		mutex_lock(&text_mutex);
 		patch_text_nosync(oldptr, altptr, alt->alt_len);
+		for (int i = 0; i < alt->alt_len; i += sizeof(u32)) {
+			u32 insn;
+			memcpy(&insn, altptr + i, sizeof(insn));
+			jl_snap_append(&(struct jl_entry){
+					.addr = (u64)(oldptr + i),
+					.new_insn = insn,
+			});
+		}
+	
 		riscv_alternative_fix_offsets(oldptr, alt->alt_len, oldptr - altptr);
 		mutex_unlock(&text_mutex);
 	}

--- a/arch/riscv/kernel/cpufeature.c
+++ b/arch/riscv/kernel/cpufeature.c
@@ -1221,16 +1221,15 @@ void __init_or_module riscv_cpufeature_patch_func(struct alt_entry *begin,
 
 		mutex_lock(&text_mutex);
 		patch_text_nosync(oldptr, altptr, alt->alt_len);
+		riscv_alternative_fix_offsets(oldptr, alt->alt_len, oldptr - altptr);
 		for (int i = 0; i < alt->alt_len; i += sizeof(u32)) {
 			u32 insn;
-			memcpy(&insn, altptr + i, sizeof(insn));
+			memcpy(&insn, oldptr + i, sizeof(insn));
 			jl_snap_append(&(struct jl_entry){
 					.addr = (u64)(oldptr + i),
 					.new_insn = insn,
 			});
 		}
-	
-		riscv_alternative_fix_offsets(oldptr, alt->alt_len, oldptr - altptr);
 		mutex_unlock(&text_mutex);
 	}
 }

--- a/arch/riscv/kernel/head.S
+++ b/arch/riscv/kernel/head.S
@@ -133,7 +133,8 @@ secondary_start_sbi:
 
 #ifndef CONFIG_RISCV_M_MODE
 	/* Enable time CSR */
-	li t0, 0x2
+	# li t0, 0x2
+	li t0, 0x7
 	csrw CSR_SCOUNTEREN, t0
 #endif
 
@@ -234,7 +235,8 @@ SYM_CODE_START(_start_kernel)
 	csrr a0, CSR_MHARTID
 #else
 	/* Enable time CSR */
-	li t0, 0x2
+	# li t0, 0x2
+	li t0, 0x7
 	csrw CSR_SCOUNTEREN, t0
 #endif /* CONFIG_RISCV_M_MODE */
 

--- a/arch/riscv/kernel/jump_label.c
+++ b/arch/riscv/kernel/jump_label.c
@@ -5,6 +5,7 @@
  * Based on arch/arm64/kernel/jump_label.c
  */
 #include <linux/jump_label.h>
+#include <linux/jump_label_patch_log.h>
 #include <linux/kernel.h>
 #include <linux/memory.h>
 #include <linux/mutex.h>
@@ -39,11 +40,13 @@ bool arch_jump_label_transform_queue(struct jump_entry *entry,
 	if (early_boot_irqs_disabled) {
 		riscv_patch_in_stop_machine = 1;
 		patch_insn_write(addr, &insn, sizeof(insn));
+		jl_snap_append(&(struct jl_entry){.addr = (u64)addr, .new_insn = insn});
 		riscv_patch_in_stop_machine = 0;
 	} else {
 		mutex_lock(&text_mutex);
 		patch_insn_write(addr, &insn, sizeof(insn));
 		mutex_unlock(&text_mutex);
+		jl_snap_append(&(struct jl_entry){.addr = (u64)addr, .new_insn = insn});
 	}
 
 	return true;

--- a/arch/riscv/kernel/vdso.c
+++ b/arch/riscv/kernel/vdso.c
@@ -33,6 +33,15 @@ static struct __vdso_info vdso_info;
 static struct __vdso_info compat_vdso_info;
 #endif
 
+unsigned int vdso_enabled __read_mostly = 1;
+
+static int __init vdso_setup(char *s)
+{
+	vdso_enabled = simple_strtoul(s, NULL, 0);
+	return 1;
+}
+__setup("vdso=", vdso_setup);
+
 static int vdso_mremap(const struct vm_special_mapping *sm,
 		       struct vm_area_struct *new_vma)
 {

--- a/include/linux/jump_label_patch_log.h
+++ b/include/linux/jump_label_patch_log.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _LINUX_JUMP_LABEL_PATCH_LOG_H
+#define _LINUX_JUMP_LABEL_PATCH_LOG_H
+
+#include <linux/types.h>
+#include <linux/jump_label.h>
+
+struct jl_entry {
+	u64 addr;            // site address
+	u32 new_insn;
+};
+
+#ifdef CONFIG_JUMP_LABEL_PATCH_LOG_SNAPSHOT
+void jl_snap_append(const struct jl_entry *e);
+void jl_snap_publish_debugfs(void);   // call later (late init)
+#else
+static inline void jl_snap_append(const struct jl_entry *e) { }
+static inline void jl_snap_publish_debugfs(void) { }
+#endif
+
+#endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -129,6 +129,7 @@ obj-$(CONFIG_PERF_EVENTS) += events/
 obj-$(CONFIG_USER_RETURN_NOTIFIER) += user-return-notifier.o
 obj-$(CONFIG_PADATA) += padata.o
 obj-$(CONFIG_JUMP_LABEL) += jump_label.o
+obj-$(CONFIG_JUMP_LABEL_PATCH_LOG_SNAPSHOT) += jump_label_patch_log.o
 obj-$(CONFIG_CONTEXT_TRACKING) += context_tracking.o
 obj-$(CONFIG_TORTURE_TEST) += torture.o
 

--- a/kernel/jump_label.c
+++ b/kernel/jump_label.c
@@ -15,6 +15,7 @@
 #include <linux/err.h>
 #include <linux/static_key.h>
 #include <linux/jump_label_ratelimit.h>
+#include <linux/jump_label_patch_log.h>
 #include <linux/bug.h>
 #include <linux/cpu.h>
 #include <asm/sections.h>

--- a/kernel/jump_label_patch_log.c
+++ b/kernel/jump_label_patch_log.c
@@ -1,7 +1,7 @@
 #include <linux/jump_label_patch_log.h>
 #include <linux/atomic.h>
 
-#define JL_MAX 65536  // tune or make it cmdline-configurable
+#define JL_MAX 8192  // tune or make it cmdline-configurable
 static struct jl_entry jl_buf[JL_MAX];
 static atomic_t jl_widx = ATOMIC_INIT(0);
 

--- a/kernel/jump_label_patch_log.c
+++ b/kernel/jump_label_patch_log.c
@@ -1,0 +1,63 @@
+#include <linux/jump_label_patch_log.h>
+#include <linux/atomic.h>
+
+#define JL_MAX 65536  // tune or make it cmdline-configurable
+static struct jl_entry jl_buf[JL_MAX];
+static atomic_t jl_widx = ATOMIC_INIT(0);
+
+#ifdef CONFIG_JUMP_LABEL_PATCH_LOG_SNAPSHOT
+void jl_snap_append(const struct jl_entry *e)
+{
+	int i = atomic_fetch_add_unless(&jl_widx, 1, JL_MAX);
+	if (i >= JL_MAX) return; // drop if full
+	jl_buf[i] = *e;
+}
+#endif
+
+#ifdef CONFIG_DEBUG_FS
+#include <linux/debugfs.h>
+#include <linux/seq_file.h>
+
+static int jl_dbg_show(struct seq_file *m, void *v)
+{
+	int i, n = min(atomic_read(&jl_widx), JL_MAX);
+	for (i = 0; i < n; i++) {
+		const struct jl_entry *e = &jl_buf[i];
+		seq_printf(m, "%llx,%08x\n",
+			(unsigned long long)e->addr,
+			e->new_insn);
+	}
+	return 0;
+}
+static int jl_dbg_open(struct inode *inode, struct file *file)
+{
+	return single_open(file, jl_dbg_show, NULL);
+}
+static const struct file_operations jl_dbg_fops = {
+	.owner = THIS_MODULE,
+	.open  = jl_dbg_open,
+	.read  = seq_read,
+	.llseek= seq_lseek,
+	.release= single_release,
+};
+
+#ifdef CONFIG_JUMP_LABEL_PATCH_LOG_SNAPSHOT
+static struct dentry *jl_dent;
+void jl_snap_publish_debugfs(void)
+{
+	if (!jl_dent)
+		jl_dent = debugfs_create_file("jump_label_snapshot", 0444,
+		                              NULL, NULL, &jl_dbg_fops);
+}
+
+static int __init jl_snap_publish_debugfs_init(void)
+{
+	jl_snap_publish_debugfs();
+	return 0;
+}
+late_initcall(jl_snap_publish_debugfs_init);
+
+#endif // CONFIG_JUMP_LABEL_PATCH_LOG_SNAPSHOT
+#else // CONFIG_DEBUG_FS
+void jl_snap_publish_debugfs(void) { }
+#endif // CONFIG_DEBUG_FS

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -117,6 +117,10 @@ EXPORT_TRACEPOINT_SYMBOL_GPL(sched_util_est_se_tp);
 EXPORT_TRACEPOINT_SYMBOL_GPL(sched_update_nr_running_tp);
 EXPORT_TRACEPOINT_SYMBOL_GPL(sched_compute_energy_tp);
 
+EXPORT_SYMBOL(__tracepoint_sched_process_exec);
+EXPORT_SYMBOL(__tracepoint_sched_process_fork);
+EXPORT_SYMBOL(__tracepoint_sched_switch);
+
 DEFINE_PER_CPU_SHARED_ALIGNED(struct rq, runqueues);
 
 /*


### PR DESCRIPTION
This PR supports logging and storing the jump label patch for offline binary analysis, including trace decoding.